### PR TITLE
feat: Expose Controller Manager image repository configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_controller_image_repository"></a> [controller\_image\_repository](#input\_controller\_image\_repository) | wandb/controller image repository | `string` | `"wandb/controller"` | no |
 | <a name="input_controller_image_tag"></a> [controller\_image\_tag](#input\_controller\_image\_tag) | wandb/controller image tag | `string` | `"latest"` | no |
 | <a name="input_enable_helm_operator"></a> [enable\_helm\_operator](#input\_enable\_helm\_operator) | Enable or disable applying and releasing W&B Operator chart | `bool` | `true` | no |
 | <a name="input_enable_helm_wandb"></a> [enable\_helm\_wandb](#input\_enable\_helm\_wandb) | Enable or disable applying and releasing CR chart | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -11,11 +11,16 @@ resource "helm_release" "operator" {
   disable_webhooks = true
   verify           = false
   // note: use count to enforce whether helm is used for release
-  count            = var.enable_helm_operator ? 1 : 0
+  count = var.enable_helm_operator ? 1 : 0
 
   set {
     name  = "image.tag"
     value = var.controller_image_tag
+  }
+
+  set {
+    name  = "image.repository"
+    value = var.controller_image_repository
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -38,3 +38,9 @@ variable "enable_helm_wandb" {
   default     = true
   description = "Enable or disable applying and releasing CR chart"
 }
+
+variable "controller_image_repository" {
+  type        = string
+  default     = "wandb/controller"
+  description = "wandb/controller image repository"
+}


### PR DESCRIPTION
This change will benefit customers with restrictions on pulling images from private repository registries.
One of our customers can only pull images from the private ECR, and this is now a blocker for them to use our upstream AWS Terraform module.
All other images required for platform installation can be passed directly via the CRD spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to customize the controller image repository via a new input: controller_image_repository (default: "wandb/controller").
- Bug Fixes
  - Fixed a configuration syntax issue that could prevent successful deployment.
- Documentation
  - Updated README Inputs table to include controller_image_repository with description and default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->